### PR TITLE
perf/ Cambiar el sequelize.sync() de force a alter: true

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@ import { users } from "./seeders/users-seed";
 // sync({ alter: true })
 // sync({ force: true })
 
-db.sequelize.sync({ force: true }).then(() => {
+db.sequelize.sync({ alter: true }).then(() => {
   app.listen(config.server.port, () => {
     console.log(
       "**** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** **** "


### PR DESCRIPTION
- Cambiar el sequelize.sync() de force:true a { alter: true } para que no de dropeen las tablas cada vez que reinicia el back.