### PR TITLE
feat/Crear ruta para admin "/setIsAdmin" y fn aux

### DIFF
--- a/models/user.ts
+++ b/models/user.ts
@@ -36,6 +36,7 @@ module.exports = (sequelize: any, DataTypes: any) => {
     endpoints!: Text;
     linkToDonate: string | undefined;
     isBanned: string | undefined;
+    isAdmin: boolean | undefined;
 
     static associate(models: any) {
       // define association here
@@ -119,6 +120,11 @@ module.exports = (sequelize: any, DataTypes: any) => {
       },
       isBanned: {
         type: DataTypes.STRING,
+        allowNull: true,
+      },
+      isAdmin: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
         allowNull: true,
       },
     },

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -78,6 +78,7 @@ async function getSomeUserInfo(userId: any) {
         linkToDonate: userInfo.linkToDonate,
         endpoints: userInfo.endpoints,
         isBanned: userInfo.isBanned,
+        isAdmin: userInfo.isAdmin,
       };
       console.log(`retornando someUserInfo: ${someUserInfo}`);
       return someUserInfo;

--- a/src/types/userTypes.ts
+++ b/src/types/userTypes.ts
@@ -14,6 +14,7 @@ export interface UserAttributes {
   endpoints: Text;
   linkToDonate: string | undefined;
   isBanned: string | undefined;
+  isAdmin: boolean | undefined;
 }
 
 export interface ISomeUserInfo {
@@ -30,6 +31,7 @@ export interface ISomeUserInfo {
   linkToDonate: string | undefined;
   endpoints: Text;
   isBanned: string | undefined;
+  isAdmin: boolean | undefined;
 }
 
 export interface IContactInfoOfOwner {


### PR DESCRIPTION
- Crear ruta "admin/setIsAdmin" para setear la prop del model User isAdmin a true o false.
 Esta ruta es para crear permisos de administrador, o sacarlos.
- Crear función auxiliar checkIfJWTisAdmin